### PR TITLE
Added support for Serilog Settings Configuration

### DIFF
--- a/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
+++ b/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
@@ -21,5 +21,11 @@ namespace Serilog.Sinks.Loki
 
             return sinkConfiguration.Http(LokiRouteBuilder.BuildPostUri(credentials.Url), batchFormatter: formatter, httpClient: client);
         }
+
+        public static LoggerConfiguration LokiHttp(this LoggerSinkConfiguration sinkConfiguration, string serverUrl)
+            => sinkConfiguration.LokiHttp(new NoAuthCredentials(serverUrl));
+
+        public static LoggerConfiguration LokiHttp(this LoggerSinkConfiguration sinkConfiguration, string serverUrl, string username, string password)
+            => sinkConfiguration.LokiHttp(new BasicAuthCredentials(serverUrl, username, password));
     }
 }


### PR DESCRIPTION
Fixes #6 
A simple Serilog Settings Configuration implementation that supports both NoAuthCredentials and BasicAuthCredentials.
Won't work with ILogLabelProvider, but it should't be a problem after merging #7, can be replaced with Enrichers, and it won't work with a custom LokiHttpClient.
