### PR TITLE
Use correct levels

### DIFF
--- a/src/Serilog.Sinks.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Loki/LokiBatchFormatter.cs
@@ -86,10 +86,13 @@ namespace Serilog.Sinks.Loki
 
         private static string GetLevel(LogEventLevel level)
         {
-            if (level == LogEventLevel.Information)
-                return "info";
-
-            return level.ToString().ToLower();
+            switch (level)
+            {
+                case LogEventLevel.Verbose: return "trace";
+                case LogEventLevel.Information: return "info";
+                case LogEventLevel.Fatal: return "critical";
+                default: return level.ToString().ToLower();
+            }
         }
     }
 }

--- a/test/Serilog.Sinks.Loki.Tests/Labels/LogLevelLabelTests.cs
+++ b/test/Serilog.Sinks.Loki.Tests/Labels/LogLevelLabelTests.cs
@@ -18,6 +18,24 @@ namespace Serilog.Sinks.Loki.Tests.Labels
         }
         
         [Fact]
+        public void VerboseLabelIsSet()
+        {
+            // Arrange
+            var log = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.LokiHttp(_credentials, httpClient: _client)
+                .CreateLogger();
+            
+            // Act
+            log.Verbose("Verbose Level");
+            log.Dispose();
+            
+            // Assert
+            var response = JsonConvert.DeserializeObject<TestResponse>(_client.Content);
+            response.Streams.First().Labels.ShouldBe("{level=\"trace\"}");
+        }
+        
+        [Fact]
         public void DebugLabelIsSet()
         {
             // Arrange
@@ -69,6 +87,24 @@ namespace Serilog.Sinks.Loki.Tests.Labels
             // Assert
             var response = JsonConvert.DeserializeObject<TestResponse>(_client.Content);
             response.Streams.First().Labels.ShouldBe("{level=\"error\"}");
+        }
+
+        [Fact]
+        public void FatalLabelIsSet()
+        {
+            // Arrange
+            var log = new LoggerConfiguration()
+                .MinimumLevel.Fatal()
+                .WriteTo.LokiHttp(_credentials, httpClient: _client)
+                .CreateLogger();
+            
+            // Act
+            log.Fatal("Fatal Level");
+            log.Dispose();
+            
+            // Assert
+            var response = JsonConvert.DeserializeObject<TestResponse>(_client.Content);
+            response.Streams.First().Labels.ShouldBe("{level=\"critical\"}");
         }
     }
 }


### PR DESCRIPTION
Verbose and Fatal log levels are not understood by Loki and have to be mapped to `trace` and `critical` accordingly.