### PR TITLE
Make the class LokiHttpClient abstract to be used in appsettings.json

### DIFF
--- a/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
+++ b/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Serilog.Sinks.Loki
+{
+  public class DefaultLokiHttpClient : LokiHttpClient
+  {
+  }
+}

--- a/src/Serilog.Sinks.Loki/LokiHttpClient.cs
+++ b/src/Serilog.Sinks.Loki/LokiHttpClient.cs
@@ -7,7 +7,7 @@ using Serilog.Sinks.Http;
 
 namespace Serilog.Sinks.Loki
 {
-    public class LokiHttpClient : IHttpClient
+    public abstract class LokiHttpClient : IHttpClient
     {
         protected readonly HttpClient HttpClient;
 

--- a/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
+++ b/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.Loki
         {
             var formatter = logLabelProvider != null ? new LokiBatchFormatter(logLabelProvider.GetLabels()) : new LokiBatchFormatter();
             
-            var client = httpClient ?? new LokiHttpClient();
+            var client = httpClient ?? new DefaultLokiHttpClient();
             if (client is LokiHttpClient c)
             {
                 c.SetAuthCredentials(credentials);


### PR DESCRIPTION
To use appsettings.json with LokiHttp, the arguments need to be of type Interface or Abstract (required by: [serilog-settings-configuration](serilog-settings-configuration)).

See code [here](https://github.com/serilog/serilog-settings-configuration/blob/0624f6368cad751f23c048a2a2a7b8d065b8e31d/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs#L60)

Example of code: 
```json
"WriteTo": [
      {
        "Name": "LokiHttp",
        "Args": {
          "credentials": "MyNamespace.MyAuthCredentials, MyAssemblyName",
          "labelProvider": "MyNamespace.MyLogLabelProvider, MyAssemblyName",
          "httpClient": "MyNamespace.MyLokiHttpClient, MyAssemblyName"
        }
      }
    ]
```