### PR TITLE
Some Exceptions do not give access to .Message

### DIFF
--- a/src/Serilog.Sinks.Loki/LokiBatchFormatter.cs
+++ b/src/Serilog.Sinks.Loki/LokiBatchFormatter.cs
@@ -53,15 +53,8 @@ namespace Serilog.Sinks.Loki
                 var sb = new StringBuilder();
                 sb.AppendLine(logEvent.RenderMessage());
                 if (logEvent.Exception != null)
-                {
-                    var e = logEvent.Exception;
-                    while (e != null)
-                    {
-                        sb.AppendLine(e.Message);
-                        sb.AppendLine(e.StackTrace);
-                        e = e.InnerException;
-                    }
-                }
+                    // AggregateException adds a Environment.Newline to the end of ToString(), so we trim it off
+                    sb.AppendLine(logEvent.Exception.ToString().TrimEnd());
 
                 foreach (KeyValuePair<string, LogEventPropertyValue> property in logEvent.Properties)
                 {


### PR DESCRIPTION
https://github.com/serilog/serilog-formatting-compact-reader/blob/dev/src/Serilog.Formatting.Compact.Reader/TextException.cs for example does not give the correct error message but instead warns about ToString()