### PR TITLE
Falco20019/pr15+22

### DIFF
--- a/src/Serilog.Sinks.Loki.Example/LogLabelProvider.cs
+++ b/src/Serilog.Sinks.Loki.Example/LogLabelProvider.cs
@@ -16,7 +16,12 @@ namespace Serilog.Sinks.Loki.Example
 
         public IList<string> PropertiesAsLabels { get; set; } = new List<string>
         {
-            "MyPropertyName"
+            "MyLabelPropertyName"
         };
+        public IList<string> PropertiesToAppend { get; set; } = new List<string>
+        {
+            "MyAppendPropertyName"
+        };
+        public LokiFormatterStrategy FormatterStrategy { get; set; } = LokiFormatterStrategy.SpecificPropertiesAsLabelsOrAppended;
     }
 }

--- a/src/Serilog.Sinks.Loki.Example/Program.cs
+++ b/src/Serilog.Sinks.Loki.Example/Program.cs
@@ -13,7 +13,7 @@ namespace Serilog.Sinks.Loki.Example
             Logger log = new LoggerConfiguration()
                         .MinimumLevel.Verbose()
                         .Enrich.FromLogContext()
-                        .Enrich.WithProperty("MyPropertyName","MyPropertyValue")
+                        .Enrich.WithProperty("MyLabelPropertyName","MyPropertyValue")
                         .Enrich.WithThreadId()
                         .WriteTo.Console()
                         .WriteTo.LokiHttp(credentials, new LogLabelProvider(), new LokiExampleHttpClient())
@@ -44,6 +44,12 @@ namespace Serilog.Sinks.Loki.Example
             {
                 log.Warning("Warning with Property A");
                 log.Fatal("Fatal with Property A");
+            }
+
+            using (LogContext.PushProperty("MyAppendPropertyName", 1))
+            {
+                log.Warning("Warning with Property MyAppendPropertyName");
+                log.Fatal("Fatal with Property MyAppendPropertyName");
             }
 
             log.Dispose();

--- a/src/Serilog.Sinks.Loki.ExampleWebApp/Models/ErrorViewModel.cs
+++ b/src/Serilog.Sinks.Loki.ExampleWebApp/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Serilog.Sinks.Loki.ExampleWebApp.Models
 {
     public class ErrorViewModel

--- a/src/Serilog.Sinks.Loki.ExampleWebApp/Startup.cs
+++ b/src/Serilog.Sinks.Loki.ExampleWebApp/Startup.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Serilog.Sinks.Loki/ContextualLabels.cs
+++ b/src/Serilog.Sinks.Loki/ContextualLabels.cs
@@ -1,5 +1,3 @@
-using Serilog.Core;
-
 namespace Serilog.Sinks.Loki
 {
 /*    public static class ContextualLabels

--- a/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
+++ b/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Serilog.Sinks.Loki
+﻿namespace Serilog.Sinks.Loki
 {
   public class DefaultLokiHttpClient : LokiHttpClient
   {

--- a/src/Serilog.Sinks.Loki/Labels/DefaultLogLabelProvider.cs
+++ b/src/Serilog.Sinks.Loki/Labels/DefaultLogLabelProvider.cs
@@ -1,14 +1,33 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Serilog.Sinks.Loki.Labels
 {
     class DefaultLogLabelProvider : ILogLabelProvider
     {
-        public IList<LokiLabel> GetLabels()
+        public DefaultLogLabelProvider() : this(null)
         {
-            return new List<LokiLabel>();
         }
 
-        public IList<string> PropertiesAsLabels { get; set; } = new List<string>();
+        public DefaultLogLabelProvider(IEnumerable<LokiLabel> labels,
+            IEnumerable<string> propertiesAsLabels = null,
+            IEnumerable<string> propertiesToAppend = null,
+            LokiFormatterStrategy formatterStrategy = LokiFormatterStrategy.SpecificPropertiesAsLabelsAndRestAppended)
+        {
+            this.Labels = labels?.ToList() ?? new List<LokiLabel>();
+            this.PropertiesAsLabels = propertiesAsLabels?.ToList() ?? new List<string>();
+            this.PropertiesToAppend = propertiesToAppend?.ToList() ?? new List<string>();
+            this.FormatterStrategy = formatterStrategy;
+        }
+
+        public IList<LokiLabel> GetLabels()
+        {
+            return this.Labels;
+        }
+        
+        private IList<LokiLabel> Labels { get; }
+        public IList<string> PropertiesAsLabels { get; }
+        public IList<string> PropertiesToAppend { get; }
+        public LokiFormatterStrategy FormatterStrategy { get; }
     }
 }

--- a/src/Serilog.Sinks.Loki/Labels/ILogLabelProvider.cs
+++ b/src/Serilog.Sinks.Loki/Labels/ILogLabelProvider.cs
@@ -5,6 +5,9 @@ namespace Serilog.Sinks.Loki.Labels
     public interface ILogLabelProvider
     {
         IList<LokiLabel> GetLabels();
-        IList<string> PropertiesAsLabels { get; set; }
+
+        IList<string> PropertiesAsLabels { get; }
+        IList<string> PropertiesToAppend { get; }
+        LokiFormatterStrategy FormatterStrategy { get; }
     }
 }

--- a/src/Serilog.Sinks.Loki/LokiFormatterStrategy.cs
+++ b/src/Serilog.Sinks.Loki/LokiFormatterStrategy.cs
@@ -1,0 +1,19 @@
+namespace Serilog.Sinks.Loki {
+    public enum LokiFormatterStrategy {
+        /// All Serilog Event properties will be sent as labels
+        AllPropertiesAsLabels,
+
+        /// Specific Serilog Event properties will be sent as labels.
+        /// The rest of properties will be discarder.
+        SpecificPropertiesAsLabelsAndRestDiscarded,
+
+        /// Specific Serilog Event properties will be sent as labels.
+        /// The rest of properties will be appended to the log message.
+        SpecificPropertiesAsLabelsAndRestAppended,
+
+        /// Specific Serilog Event properties will be sent as labels.
+        /// Other specific properties will be appended to the log message.
+        /// The rest of properties will be discarded
+        SpecificPropertiesAsLabelsOrAppended
+    }
+}

--- a/src/Serilog.Sinks.Loki/LokiSinkConfiguration.cs
+++ b/src/Serilog.Sinks.Loki/LokiSinkConfiguration.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Serilog.Sinks.Http;
+using Serilog.Sinks.Loki.Labels;
+
+namespace Serilog.Sinks.Loki
+{
+    public class LokiSinkConfiguration
+    {
+        public string LokiUrl { get; set; }
+        public string LokiUsername { get; set; }
+        public string LokiPassword { get; set; }
+        public ILogLabelProvider LogLabelProvider { get; set; }
+        public IHttpClient HttpClient { get; set; }
+    }
+}

--- a/test/Serilog.Sinks.Loki.Tests/Fixtures/HttpClientTestFixture.cs
+++ b/test/Serilog.Sinks.Loki.Tests/Fixtures/HttpClientTestFixture.cs
@@ -1,6 +1,4 @@
 using System;
-using JustEat.HttpClientInterception;
-using Xunit;
 
 namespace Serilog.Sinks.Loki.Tests
 {

--- a/test/Serilog.Sinks.Loki.Tests/Infrastructure/TestLabelProvider.cs
+++ b/test/Serilog.Sinks.Loki.Tests/Infrastructure/TestLabelProvider.cs
@@ -14,5 +14,7 @@ namespace Serilog.Sinks.Loki.Tests.Infrastructure
         }
 
         public IList<string> PropertiesAsLabels { get; set; } = new List<string>();
+        public IList<string> PropertiesToAppend { get; set; } = new List<string>();
+        public LokiFormatterStrategy FormatterStrategy { get; set; } = LokiFormatterStrategy.SpecificPropertiesAsLabelsAndRestAppended;
     }
 }

--- a/test/Serilog.Sinks.Loki.Tests/Labels/LocalLabelsTests.cs
+++ b/test/Serilog.Sinks.Loki.Tests/Labels/LocalLabelsTests.cs
@@ -1,7 +1,4 @@
-using System.Linq;
-using Newtonsoft.Json;
 using Serilog.Sinks.Loki.Tests.Infrastructure;
-using Shouldly;
 using Xunit;
 
 namespace Serilog.Sinks.Loki.Tests.Labels


### PR DESCRIPTION
Merges the logic of #15 and #22 to fix #30.

This allows to use `ILogLabelProvider` as designed in #15 to set labels and define what properties to use. I only extended the interface to also hold the `PropertiesToAppend` and `FormatterStrategy` from #22 which were otherwise duplicated in `LokiBatchFormatter` and `LokiSinkConfiguration`.

`ILogLabelProvider` is now also requested at usage, not at instantiation. This allows to modify the data during runtime. `DefaultLogLabelProvider` also now has a `ctor` which allows setting the fields without doing a implementation yourself for easy cases.

I also fixed the usage of `logEvent.RenderMessage()` which adds additional quoting by applying the suggestion from https://github.com/serilog/serilog/issues/936.