### PR TITLE
Add support for custom TextFormatters. 

### DIFF
--- a/src/Serilog.Sinks.Loki/LokiSinkConfiguration.cs
+++ b/src/Serilog.Sinks.Loki/LokiSinkConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using Serilog.Formatting;
 using Serilog.Sinks.Http;
 using Serilog.Sinks.Loki.Labels;
 
@@ -18,5 +19,6 @@ namespace Serilog.Sinks.Loki
         public int BatchPostingLimit { get; set; } = 1000;
         public int? QueueLimit { get; set; }
         public TimeSpan? Period { get; set; }
+        public ITextFormatter TextFormatter { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
+++ b/src/Serilog.Sinks.Loki/LokiSinkExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using Serilog.Configuration;
+using Serilog.Formatting;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.Http;
 using Serilog.Sinks.Loki.Labels;
@@ -18,7 +19,7 @@ namespace Serilog.Sinks.Loki
                 : new BasicAuthCredentials(lokiConfig.LokiUrl, lokiConfig.LokiUsername, lokiConfig.LokiPassword);
 
             return LokiHttpImpl(serilogConfig, credentials, lokiConfig.LogLabelProvider, lokiConfig.HttpClient,
-                lokiConfig.OutputTemplate, lokiConfig.FormatProvider, lokiConfig.BatchPostingLimit,
+                lokiConfig.OutputTemplate, lokiConfig.FormatProvider, lokiConfig.TextFormatter, lokiConfig.BatchPostingLimit,
                 lokiConfig.QueueLimit, lokiConfig.Period);
         }
 
@@ -29,6 +30,7 @@ namespace Serilog.Sinks.Loki
             IHttpClient httpClient,
             string outputTemplate,
             IFormatProvider formatProvider,
+            ITextFormatter textFormatter,
             int batchPostingLimit,
             int? queueLimit,
             TimeSpan? period)
@@ -42,8 +44,8 @@ namespace Serilog.Sinks.Loki
 
             return sinkConfiguration.Http(LokiRouteBuilder.BuildPostUri(credentials.Url),
                 batchFormatter: formatter,
-                textFormatter: new MessageTemplateTextFormatter(outputTemplate, formatProvider),
                 httpClient: client,
+                textFormatter: textFormatter ?? new MessageTemplateTextFormatter(outputTemplate, formatProvider),
                 batchPostingLimit: batchPostingLimit,
                 queueLimit: queueLimit,
                 period: period);


### PR DESCRIPTION
This includes the changes from #40 I will rebase when that one is in.

This allows us to change the TextFormatter in the config like so:

```
{
  "Serilog": {
    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Loki" ],
    "WriteTo": [
      {
        "Name": "Console"
		"Args": {
          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
        }
      },
      {
        "Name": "LokiHttp",
        "Args": {
          "serverUrl": "http://loki.monitoring:3100",
          "labelProvider": "CustomPackage.CalcasaLogLabelProvider, Calcasa.ServiceBase",
          "textFormatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
        }
      }
    ]
  }
}
```

@JosephWoodward I'd love it if this (together with #40) could make it in before the new version mentioned in #38 