### PR TITLE
Add GitHub Action for Releasing to NuGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release-pipeline
+
+on:
+  release:
+    types:
+      - created
+
+
+jobs:
+  release-nuget:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Run tests
+      run: dotnet test
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Publish
+      uses: brandedoutcast/publish-nuget@v2
+      with:
+          PROJECT_FILE_PATH: src/Serilog.Sinks.Loki/Serilog.Sinks.Loki.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true


### PR DESCRIPTION
I found this to be quite useful for another project. The pipeline is largely copied from https://github.com/michaelosthege/hagelkorn/blob/master/.github/workflows/release.yml#L48-L66

All you need to add is a repository secret in the GitHub repository settings:

![grafik](https://user-images.githubusercontent.com/5894642/123868310-cf53d480-d92f-11eb-89ce-38c2111b6b2e.png)

Then you can make new releases by creating them in GitHub. No need to run any CLI things by hand.

Disclaimer: I'm secretely hoping that this helps you @JosephWoodward to make a new release, since I'm blocked by #46 that I _hope_ could go away with a new version.