### PR TITLE
Allow using base ctor on DefaultLokiHttpClient

### DIFF
--- a/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
+++ b/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
@@ -2,5 +2,6 @@
 {
   public class DefaultLokiHttpClient : LokiHttpClient
   {
+    public DefaultLokiHttpClient(HttpClient httpClient = null) : base(httpClient) {}
   }
 }

--- a/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
+++ b/src/Serilog.Sinks.Loki/DefaultLokiHttpClient.cs
@@ -1,4 +1,6 @@
-﻿namespace Serilog.Sinks.Loki
+using System.Net.Http;
+
+namespace Serilog.Sinks.Loki
 {
   public class DefaultLokiHttpClient : LokiHttpClient
   {


### PR DESCRIPTION
I just saw today that there is no way to use the ctor of `LokiHttpClient` without having to create a new inherited instance, since `DefaultLokiHttpClient` was missing to add a ctor.